### PR TITLE
:sparkles: Add bulk endpoints 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-19
 
 DEPENDENCIES
   middleman (~> 4.3)
@@ -133,4 +134,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   2.1.4
+   2.2.0

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -56,7 +56,7 @@ When using <code>curl</code> on Microsoft Windows you need to replace single-quo
 All requests must specify an Authorization header.
 </aside>
 
-## API Account Status
+## Account Status
 
 ```shell
 curl "https://api.sigmaratings.com/v1/account_status"

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -283,13 +283,13 @@ Performs multiple requests of the risk scoring endpoint in a single call. It agg
 <aside class="notice">
 This endpoint requires the Content-Type to be set to application/x-ndjson. The Content-Type requires a new line
 to separate each entry, JSON entries must not include `\n`'s as delimiters. <a href='http://ndjson.org'>ndjson specification reference</a>
+</aside>
 
 The following is an example of the input file required for the bulk request endpoint:
 ```json
 {"id":"1", "Yardpoint Sales LLP"}
 {"id":"2", "Sigma Ratings"}
 ```
-</aside>
 
 ## API Bulk status
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -87,7 +87,7 @@ This endpoint retrieves information about your API key.
 
 ## Risk Scoring
 
-Sigma's Risk Scoring API is Sigma's primary API that powers compliant commercial and financial relationships globally.  The API brings together over 60 proprietary financial crime-related risk indicators to derive entity risk scores from Sigma's database, which now includes 750 million companies, people and other legal entities. Calling the API with an entity name returns a Sigma Risk Score for the specified entity.
+Sigma's Risk Scoring powers compliant commercial and financial relationships globally.  It brings together over 60 proprietary financial crime-related risk indicators to derive entity risk scores from Sigma's database, which now includes 750 million companies, people and other legal entities. Calling the endpoint with an entity name returns a Sigma Risk Score for the specified entity.
 
 
 ```shell
@@ -278,11 +278,17 @@ curl "https://api.sigmaratings.com/v1/bulk"
 }
 ```
 
-This endpoint creates a bulk request.
+Performs multiple requests of the risk scoring endpoint in a single call. It aggregates the results into two files: a summary file, that aggregates all the data collected from each individual request, and a details file, which contains additional details for each individual request. The endpoint provides an `id` which can be used to verify the status of the bulk request.
 
 <aside class="notice">
 This endpoint requires the Content-Type to be set to application/x-ndjson. The Content-Type requires a new line
 to separate each entry, JSON entries must not include `\n`'s as delimiters. <a href='http://ndjson.org'>ndjson specification reference</a>
+
+The following is an example of the input file required for the bulk request endpoint:
+```json
+{"id":"1", "Yardpoint Sales LLP"}
+{"id":"2", "Sigma Ratings"}
+```
 </aside>
 
 ## API Bulk status
@@ -310,7 +316,11 @@ curl "https://api.sigmaratings.com/v1/bulk/:id"
 }
 ```
 
-This endpoint retrieves information about your API key.
+This endpoint retrieves information about your bulk request. When the request completes, it generates a `presigned_url`. This url allows acccess to a zip file of the bulk request that was requested. The zip file will contain the following files:
+
+- A summary.json: High level summary of each individual request
+- A details.json: Describes details for each of the Risk Scoring requests that was executed.
+- An errors.json: Only present if there were errors during the execution of the bulk request. If present, it will contain the `id`s and errors where the request failed.
 
 ### Response details
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -241,3 +241,88 @@ Type | Description
 `Trade` | Indicates the address was found in shipping records. | 
 `Operating` | Indicates the address was found in corporate records or third party company profiles. |
 `Unspecified` | Indicates the address found but no available information on address type. |
+
+
+### HTTP Request
+
+`POST https://api.sigmaratings.com/v1/bulk`
+
+### URL Parameters
+
+Parameter |  Description | Type | Default
+--------- |  ----------- | ------- | ----------
+threshold | A decimal representation of match strength | float | 0.95
+category | <name of category here> | string | <insert default value here>
+
+### Request body
+
+
+## API Bulk
+
+```shell
+cat entities.json
+{"id":"1", "YARDPOINT SALES LLP"}
+{"id":"2", "Sigma Ratings"}
+curl "https://api.sigmaratings.com/v1/bulk"
+  -H "Authorization: mZGVtbzpwQDU1dzByZA==" -H "Content-Type: application/x-ndjson"
+  -XPOST --data-binary "@entities.json"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": "1e67becc-9405-4a3c-b4d0-78144bc8bba4",
+  "message": "Request submitted",
+  "created_at": "2016-11-28T00:00:00.0000000Z"
+}
+```
+
+This endpoint creates a bulk request.
+
+<aside class="notice">
+This endpoint requires the Content-Type to be set to application/x-ndjson. The Content-Type requires a new line
+to separate each entry, JSON entries must not include `\n`'s as delimiters. <a href='http://ndjson.org'>ndjson specification reference</a>
+</aside>
+
+## API Bulk status
+
+```shell
+curl "https://api.sigmaratings.com/v1/bulk/:id"
+  -H "Authorization: mZGVtbzpwQDU1dzByZA=="
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": "c9ebf761-8851-4550-be7e-a14d07e0e57a",
+  "status": "Completed",
+  "presigned_url": "https://sigmaratings-uploads.s3.amazonaws.com/c9ebf761-8851-4550-be7e-a14d07e0e57a/c9ebf761-8851-4550-be7e-a14d07e0e57a.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAQ7CCVENTOOV7CZ7M%2F20201210%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20201210T213944Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=d1f8b6b2424be13692cff876775c27c25f698970fd4735ad7a1a2451593db23f",
+  "created_at": "2016-11-28T00:00:00.0000000Z",
+  "completed_at": "2016-11-29T00:00:00.0000000Z",
+  "batches": {
+    "total_num": 1,
+    "total_num_completed": 1,
+    "total_num_processing": 0,
+    "total_num_remaining": 0
+  }
+}
+```
+
+This endpoint retrieves information about your API key.
+
+### Response details
+
+Field |  Description 
+--------- |  -----------
+`id` | An UUID to reference the request 
+`status` | Status of request 
+`presigned_url` | url to download request submitted. This field is only present when the request is completed. 
+`created_at` | Date when request was created
+`completed_at` | Date when request was completed
+`batches` | Status of request indicating processing status
+
+
+
+

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -251,8 +251,8 @@ Type | Description
 
 Parameter |  Description | Type | Default
 --------- |  ----------- | ------- | ----------
-threshold | A decimal representation of match strength | float | 0.95
-category | <name of category here> | string | <insert default value here>
+`threshold` | A decimal representation of match strength | float | 0.95
+`category` | <name of category here> | string | <insert default value here>
 
 ### Request body
 


### PR DESCRIPTION
Updates documentation to include:
- `/v1/bulk` endpoint
- `/v1/bulk/:id` status endpoint